### PR TITLE
Added text that describes where to get the criterion methods.

### DIFF
--- a/src/en/ref/Domain Classes/createCriteria.gdoc
+++ b/src/en/ref/Domain Classes/createCriteria.gdoc
@@ -6,6 +6,8 @@ Creates and returns an instance of Grails' [HibernateCriteriaBuilder|http://grai
 
 h2. Examples
 
+The criterion methods (like, and, or, between etc) used to build the criteria can be statically imported from HibernateCriteriaBuilder (as in the following examples in this document), or written as "c.like(...)", "c.between(...)" etc.
+
 {code:java}
 def c = Account.createCriteria()
 def results = c.list {


### PR DESCRIPTION
It can very difficult to figure out where the criterion methods are. Copy-pasting the examples on this page leads to a lot of syntax errors. I added a line of text that makes this document more easy to understand.